### PR TITLE
Add playful belly scan page with parent controls

### DIFF
--- a/belly-scanner.html
+++ b/belly-scanner.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Magic Belly Scan</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;700&family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --ink: #0f172a;
+            --foam: #e0f2fe;
+            --accent: #f97316;
+            --accent-dark: #ea580c;
+            --card: #ffffff;
+            --muted: #475569;
+            --border: #cbd5e1;
+            --success: #22c55e;
+            --warning: #facc15;
+            --danger: #ef4444;
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            font-family: 'Inter', system-ui, -apple-system, sans-serif;
+            background: radial-gradient(circle at 20% 20%, #e0f2fe 0, #f8fafc 30%, #f8fafc 60%, #e0f2fe 100%);
+            color: var(--ink);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+        }
+
+        .app {
+            width: min(960px, 100%);
+            background: var(--card);
+            border: 1px solid var(--border);
+            box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
+            border-radius: 18px;
+            overflow: hidden;
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 20px 24px;
+            background: linear-gradient(135deg, #0ea5e9, #22c55e);
+            color: #fff;
+        }
+
+        header h1 {
+            margin: 0;
+            font-family: 'Baloo 2', cursive;
+            font-size: 28px;
+            letter-spacing: 0.5px;
+        }
+
+        header .badge {
+            background: rgba(255,255,255,0.18);
+            border: 1px solid rgba(255,255,255,0.4);
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-weight: 600;
+            font-size: 14px;
+        }
+
+        main {
+            display: grid;
+            grid-template-columns: 2fr 1.1fr;
+            gap: 16px;
+            padding: 24px;
+        }
+
+        .card {
+            background: #fff;
+            border: 1px solid var(--border);
+            border-radius: 14px;
+            padding: 18px;
+            box-shadow: 0 8px 28px rgba(15, 23, 42, 0.04);
+        }
+
+        .card h2 {
+            margin: 0 0 10px;
+            font-size: 22px;
+        }
+
+        .card p {
+            margin: 0 0 12px;
+            color: var(--muted);
+            line-height: 1.6;
+        }
+
+        .scan-panel {
+            text-align: center;
+            border: 2px dashed var(--border);
+            padding: 22px;
+            border-radius: 14px;
+            background: linear-gradient(120deg, rgba(14, 165, 233, 0.08), rgba(250, 204, 21, 0.08));
+        }
+
+        .belly-outline {
+            width: 180px;
+            height: 180px;
+            margin: 0 auto 14px;
+            background: radial-gradient(circle at 40% 30%, #fde68a, #f97316 65%);
+            border-radius: 50% 50% 45% 55%;
+            position: relative;
+            box-shadow: 0 0 0 12px rgba(255,255,255,0.75), 0 12px 28px rgba(0,0,0,0.08);
+        }
+
+        .belly-outline::after {
+            content: '';
+            position: absolute;
+            width: 80px;
+            height: 80px;
+            background: rgba(255,255,255,0.4);
+            top: 16px;
+            left: 20px;
+            border-radius: 50%;
+            filter: blur(1px);
+        }
+
+        .scan-button {
+            background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+            border: none;
+            color: #fff;
+            font-weight: 700;
+            font-size: 18px;
+            padding: 14px 24px;
+            border-radius: 999px;
+            cursor: pointer;
+            box-shadow: 0 10px 22px rgba(234, 88, 12, 0.28);
+            transition: transform 0.12s ease, box-shadow 0.12s ease;
+        }
+
+        .scan-button:disabled {
+            opacity: 0.7;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+
+        .scan-button:not(:disabled):hover { transform: translateY(-2px); }
+
+        .scan-button:not(:disabled):active { transform: translateY(0); }
+
+        .progress {
+            height: 10px;
+            background: #e2e8f0;
+            border-radius: 999px;
+            overflow: hidden;
+            margin: 16px 0 12px;
+        }
+
+        .progress span {
+            display: block;
+            height: 100%;
+            width: 0;
+            background: linear-gradient(90deg, #0ea5e9, #22c55e);
+            border-radius: inherit;
+            transition: width 0.1s linear;
+        }
+
+        .scan-status {
+            font-weight: 700;
+            letter-spacing: 0.5px;
+            color: var(--muted);
+            margin-bottom: 8px;
+        }
+
+        .result {
+            margin-top: 8px;
+            padding: 16px;
+            background: #f8fafc;
+            border: 1px dashed var(--border);
+            border-radius: 12px;
+            text-align: left;
+        }
+
+        .result strong { font-size: 22px; color: var(--ink); }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: #e2f3ff;
+            color: #075985;
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-weight: 600;
+            margin-top: 8px;
+            font-size: 14px;
+        }
+
+        .admin-toggle {
+            appearance: none;
+            background: transparent;
+            border: 1px solid rgba(255,255,255,0.5);
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 10px;
+            cursor: pointer;
+            font-weight: 600;
+        }
+
+        .admin {
+            display: none;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .admin.active { display: flex; }
+
+        .admin label {
+            display: flex;
+            justify-content: space-between;
+            font-weight: 600;
+        }
+
+        .slider-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        input[type="range"] {
+            flex: 1;
+            accent-color: var(--accent);
+        }
+
+        .preset-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .preset-buttons button {
+            border: 1px solid var(--border);
+            background: #f8fafc;
+            padding: 8px 12px;
+            border-radius: 999px;
+            cursor: pointer;
+            font-weight: 600;
+            transition: border-color 0.15s ease, color 0.15s ease;
+        }
+
+        .preset-buttons button.active {
+            background: #ecfeff;
+            border-color: #06b6d4;
+            color: #0f172a;
+        }
+
+        .note {
+            font-size: 14px;
+            color: var(--muted);
+        }
+
+        @media (max-width: 820px) {
+            main { grid-template-columns: 1fr; }
+            header { align-items: flex-start; gap: 12px; }
+            .admin-toggle { align-self: flex-end; }
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <header>
+            <div>
+                <h1>BellyScan 3000</h1>
+                <div class="badge">For playful parents + curious kiddos</div>
+            </div>
+            <button class="admin-toggle" id="adminToggle" type="button">Parent Controls</button>
+        </header>
+
+        <main>
+            <section class="card">
+                <h2>Hold to the belly &amp; tap "Start Scan"</h2>
+                <p>Get a totally real* reading on how full that tiny tummy is. Lights, sounds, and dramatic reading not included.</p>
+
+                <div class="scan-panel">
+                    <div class="belly-outline" aria-hidden="true"></div>
+                    <button class="scan-button" id="scanBtn">Start Scan</button>
+                    <div class="progress" role="progressbar" aria-label="Scan progress">
+                        <span id="progressFill"></span>
+                    </div>
+                    <div class="scan-status" id="scanStatus">Ready to scan.</div>
+                    <div class="result" id="result">
+                        <strong id="resultValue">--%</strong>
+                        <p id="resultMessage">Tap start to check fullness.</p>
+                        <div class="pill" id="resultBadge">Parent-set reading</div>
+                    </div>
+                </div>
+                <p class="note">*It’s make-believe magic. Parents pick the outcome in the controls.</p>
+            </section>
+
+            <aside class="card">
+                <h2>Parent station</h2>
+                <p>Pick the result before scanning. Quick presets make it easy mid-meal.</p>
+                <div class="admin" id="adminPanel">
+                    <label for="fullnessSlider">Fullness level <span id="fullnessValue">70%</span></label>
+                    <div class="slider-row">
+                        <input type="range" id="fullnessSlider" min="0" max="100" value="70">
+                    </div>
+                    <div class="preset-buttons" id="presets">
+                        <button data-value="10">Hungry</button>
+                        <button data-value="35">Snack-ish</button>
+                        <button data-value="70" class="active">Pretty Full</button>
+                        <button data-value="95">Bursting!</button>
+                        <button data-value="-1">Let it Randomize</button>
+                    </div>
+                    <p class="note">The slider value (or a preset) is used for the next scan. Random will pick a playful number every time.</p>
+                </div>
+            </aside>
+        </main>
+    </div>
+
+    <script>
+        const scanBtn = document.getElementById('scanBtn');
+        const progressFill = document.getElementById('progressFill');
+        const scanStatus = document.getElementById('scanStatus');
+        const resultValue = document.getElementById('resultValue');
+        const resultMessage = document.getElementById('resultMessage');
+        const resultBadge = document.getElementById('resultBadge');
+        const adminToggle = document.getElementById('adminToggle');
+        const adminPanel = document.getElementById('adminPanel');
+        const fullnessSlider = document.getElementById('fullnessSlider');
+        const fullnessValue = document.getElementById('fullnessValue');
+        const presets = document.getElementById('presets');
+
+        let currentSetting = 70;
+        let scanTimer = null;
+
+        const messages = [
+            value => value > 90 ? 'Whoa! That belly is packed. Time for a cozy movie.' : null,
+            value => value > 70 ? 'Looks pretty satisfied. Dessert negotiations may begin.' : null,
+            value => value > 50 ? 'Half full—there might be room for a veggie or two.' : null,
+            value => value > 30 ? 'Running low. A snack could save the day.' : null,
+            value => 'Incoming hanger detected. Deploy snacks immediately!'
+        ];
+
+        function updateSlider(value) {
+            fullnessSlider.value = value;
+            fullnessValue.textContent = `${value}%`;
+        }
+
+        function setCurrentSetting(value) {
+            currentSetting = value;
+            updateSlider(value === -1 ? 50 : value);
+            Array.from(presets.querySelectorAll('button')).forEach(btn => {
+                btn.classList.toggle('active', Number(btn.dataset.value) === value);
+            });
+            resultBadge.textContent = value === -1 ? 'Randomized reading' : 'Parent-set reading';
+        }
+
+        function fakeScan(targetValue) {
+            scanBtn.disabled = true;
+            let progress = 0;
+            scanStatus.textContent = 'Scanning... hold steady!';
+            progressFill.style.width = '0%';
+            resultMessage.textContent = 'Calibrating giggles...';
+
+            scanTimer = setInterval(() => {
+                progress = Math.min(100, progress + Math.random() * 18);
+                progressFill.style.width = `${progress}%`;
+                if (progress >= 100) {
+                    clearInterval(scanTimer);
+                    revealResult(targetValue);
+                }
+            }, 220);
+        }
+
+        function revealResult(targetValue) {
+            const finalValue = targetValue === -1 ? Math.floor(Math.random() * 101) : targetValue;
+            resultValue.textContent = `${finalValue}% full`;
+            const message = messages.map(fn => fn(finalValue)).find(Boolean);
+            resultMessage.textContent = message || 'Mysterious readings... try another scan!';
+            scanStatus.textContent = 'Scan complete!';
+            scanBtn.disabled = false;
+            progressFill.style.width = '100%';
+        }
+
+        scanBtn.addEventListener('click', () => {
+            if (scanBtn.disabled) return;
+            if (scanTimer) clearInterval(scanTimer);
+            fakeScan(currentSetting);
+        });
+
+        fullnessSlider.addEventListener('input', (event) => {
+            const value = Number(event.target.value);
+            fullnessValue.textContent = `${value}%`;
+            currentSetting = value;
+            Array.from(presets.querySelectorAll('button')).forEach(btn => btn.classList.remove('active'));
+            resultBadge.textContent = 'Parent-set reading';
+        });
+
+        presets.addEventListener('click', (event) => {
+            if (event.target.tagName !== 'BUTTON') return;
+            const value = Number(event.target.dataset.value);
+            setCurrentSetting(value);
+        });
+
+        adminToggle.addEventListener('click', () => {
+            adminPanel.classList.toggle('active');
+            adminToggle.textContent = adminPanel.classList.contains('active') ? 'Hide Parent Controls' : 'Parent Controls';
+        });
+
+        // Initial state
+        updateSlider(currentSetting);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a playful BellyScan 3000 experience with fake scanning animation and results
- add parent controls with slider/presets to set or randomize the fullness percentage
- style the page with responsive layout and friendly visuals for kids

## Testing
- not run (static page)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693811f6dfec832da6d07f3b78cf9ef0)